### PR TITLE
Wrap hubHost in quotes in node config

### DIFF
--- a/templates/default/node_config.erb
+++ b/templates/default/node_config.erb
@@ -5,7 +5,7 @@
     "proxy": "<%= @resource.proxy %>",
     "maxSession": <%= @resource.maxSession %>,
     "port": <%= @resource.port %>,
-    "host": <%= @resource.host %>,
+    "host": "<%= @resource.host %>",
     "register": <%= @resource.register %>,
     "registerCycle": <%= @resource.registerCycle %>,
     "hubPort": <%= @resource.hubPort %>,

--- a/templates/default/node_config.erb
+++ b/templates/default/node_config.erb
@@ -9,6 +9,6 @@
     "register": <%= @resource.register %>,
     "registerCycle": <%= @resource.registerCycle %>,
     "hubPort": <%= @resource.hubPort %>,
-    "hubHost": <%= @resource.hubHost %>
+    "hubHost": "<%= @resource.hubHost %>"
   }
 }


### PR DESCRIPTION
The hubHost is a string and should be wrapped in quotes. I think this is causing my node to not connect.
