### PR TITLE
Add startup node script to ProgramData directory.

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -28,7 +28,7 @@ def selenium_windows_service(name, exec, args)
 end
 
 # http://sqa.stackexchange.com/a/6267
-def selenium_windows_gui_service(name, exec, args, username)
+def selenium_windows_gui_service(name, exec, args)
   cmd = "#{selenium_home}/bin/#{name}.cmd"
 
   file cmd do
@@ -37,7 +37,7 @@ def selenium_windows_gui_service(name, exec, args, username)
     notifies :request_reboot, "reboot[Reboot to start #{name}]"
   end
 
-  startup_path = "C:\\Users\\#{username}\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup"
+  startup_path = "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Startup"
 
   ruby_block 'hack to mkdir on windows' do
     block do

--- a/providers/node.rb
+++ b/providers/node.rb
@@ -38,7 +38,7 @@ action :install do
 
   case node['platform']
   when 'windows'
-    selenium_windows_gui_service(new_resource.servicename, selenium_java_exec, args, new_resource.username)
+    selenium_windows_gui_service(new_resource.servicename, selenium_java_exec, args)
     selenium_autologon(new_resource.username, new_resource.password)
 
     selenium_windows_firewall(new_resource.servicename, new_resource.port)


### PR DESCRIPTION
At the moment, selenium_windows_gui_service() creates `C:\\Users\\#{username}\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\selenium_node.lnk`

In Windows 10, at least, even if the target user exist, in a new system there would not be any user directory file already as our target user has never logged in before. So, instead of creating the link in the user's directory it should be created in `C:\\AppDirectory`, as it targets any user.